### PR TITLE
adding reserved_by and reserved_at to push_messages, so multiple daemons can run

### DIFF
--- a/lib/generators/templates/migrations/add_reservations.rb
+++ b/lib/generators/templates/migrations/add_reservations.rb
@@ -1,0 +1,17 @@
+class AddReservations < ActiveRecord::Migration
+  def self.up
+    add_column :push_messages, :reserved_by, :string, :default => nil
+    add_column :push_messages, :reserved_until, :datetime
+    add_index :push_messages, :app
+    add_index :push_messages, :reserved_by
+    add_index :push_messages, :reserved_until
+  end
+
+  def self.down
+    remove_index :push_messages, :reserved_until
+    remove_index :push_messages, :reserved_by
+    remove_index :push_messages, :app
+    remove_column :push_messages, :reserved_until
+    remove_column :push_messages, :reserved_by
+  end
+end

--- a/lib/push/daemon/feeder.rb
+++ b/lib/push/daemon/feeder.rb
@@ -25,9 +25,13 @@ module Push
           sweep  # re-queue expired jobs
 
           with_database_reconnect_and_retry(name) do
-            Push::Message.where(:reserved_by => nil).ready_for_delivery.find_in_batches(:batch_size => BATCH_SIZE) do |batch|
-              enqueue_notifications(batch)
-            end
+            begin
+              num_reserved = Push::Message.where(:reserved_by => nil).ready_for_delivery.limit(BATCH_SIZE).update_all(
+                {:reserved_by => us, :reserved_until => Time.now + RESERVATION_TIME }
+              )
+              enqueue_notifications if num_reserved > 0
+
+            end while num_reserved > 0
           end
 
           interruptible_sleep config.push_poll
@@ -54,25 +58,14 @@ module Push
         end
       end
 
-      def self.enqueue_notifications(batch)
+      def self.enqueue_notifications
         begin
           ready_apps = Push::Daemon::App.ready
-          reserved_until = Time.now + RESERVATION_TIME
 
-          # First reserve the notifications for delivery by this instance of the daemon
-          num_reserved = batch.update_all(
-            {:reserved_by => us, :reserved_until => reserved_until},
-            :conditions => {:reserved_by => nil} # make sure noone else beat us to it
-          )
-          # if we succeeded with the reservation, then process the notifications
-          if num_reserved > 0
-            Push::Message.where(:reserved_by => us).find_each do |notification|
-              if ready_apps.include?(notification.app) && (notification.reserved_until >= Time.now)
-                Push::Daemon::App.deliver(notification)
-              end
+          Push::Message.where(:reserved_by => us).find_each do |notification|
+            if ready_apps.include?(notification.app) && (notification.reserved_until >= Time.now)
+              Push::Daemon::App.deliver(notification)
             end
-          else
-            # someone else beat us to it, or there are no notifications to be processed
           end
         rescue StandardError => e
           Push::Daemon.logger.error(e)

--- a/lib/push/daemon/feeder.rb
+++ b/lib/push/daemon/feeder.rb
@@ -1,11 +1,20 @@
+require 'socket'
+
 module Push
   module Daemon
     class Feeder
       extend DatabaseReconnectable
       extend InterruptibleSleep
 
+      RESERVATION_TIME = 2.minutes
+      MAX_TASKS   = 100
+
       def self.name
         "Feeder"
+      end
+
+      def self.us
+        Socket.gethostname + '_' + $$.to_s
       end
 
       def self.start(config)
@@ -13,6 +22,7 @@ module Push
 
         loop do
           break if @stop
+          sweep
           enqueue_notifications
           interruptible_sleep config.push_poll
         end
@@ -25,12 +35,37 @@ module Push
 
       protected
 
+      def self.sweep
+        begin
+          with_database_reconnect_and_retry(name) do
+            # re-queue notifications with stale reservations (in case other daemon died)
+            Push::Message.where("reserved_until < ?", Time.now).update_all(
+              {:reserved_by => nil, :reserved_until => nil}
+            )
+          end
+        rescue StandardError => e
+          Push::Daemon.logger.error(e)
+        end
+      end
+
       def self.enqueue_notifications
         begin
           with_database_reconnect_and_retry(name) do
-            ready_apps = Push::Daemon::App.ready
-            Push::Message.ready_for_delivery.find_each do |notification|
-              Push::Daemon::App.deliver(notification) if ready_apps.include?(notification.app)
+            Push::Daemon::App.ready.each do |app|
+              reserved_until = Time.now + RESERVATION_TIME
+
+              # First reserve the notifications for delivery by this instance of the daemon
+              num_reserved = Push::Message.ready_for_delivery.where(:app => app).update_all(
+                {:reserved_by => us, :reserved_until => reserved_until}, :limit => MAX_TASKS
+              )
+              # if we succeeded with the reservation, then process the notifications
+              if num_reserved > 0
+                Push::Messages.where(:reserved_by => us).find_each do |notification|
+                  Push::Daemon::App.deliver(notification)
+                end
+              else
+                # someone else beat us to it
+              end
             end
           end
         rescue StandardError => e


### PR DESCRIPTION
this adds columns :reserved_by and :reserved_until to allow multiple daemons to run on different hosts
without sending notifications multiple times.

Each running daemon will use it's own id (hostname + PID) to reserve notifications, and mark them
reserved_until a given time.

The main loop of the feeder is modified to first sweep expired reservations, and then deliver notifications.

When delivering notifications, it first reserves up to MAX_TASKS notifications per app type, and then
delivers them

this needs the other pull request which allows multiple migrations.
Users which upgrade to this need to re-run 'rails g push' to create the missing migrations.
