### PR TITLE
Check database connected performance

### DIFF
--- a/lib/push/daemon/database_reconnectable.rb
+++ b/lib/push/daemon/database_reconnectable.rb
@@ -51,7 +51,7 @@ module Push
 
       def check_database_is_connected
         # Simply asking the adapter for the connection state is not sufficient.
-        Push::Message.count
+        Push::Message.take
       end
 
       def sleep_to_avoid_thrashing


### PR DESCRIPTION
Counting the number of rows in a PostgreSQL table is slow. Just fetch a
row or nil if table is empty.